### PR TITLE
Added references to sys container images in public Nestybox DockerHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ $ sudo rmmod nbox_shiftfs
 $ sudo userdel sysboxd
 ```
 
+## Contact
+
+Please contact us at `contact@nestybox.com` for any questions. We will
+be happy to help.
+
 ## Thank You!
 
 We thank you **very much** for using Sysboxd. We hope you find it useful.

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,70 @@
+Nestybox System Container Dockerfiles
+=====================================
+
+This directory contains the Dockerfiles for system container images
+uploaded to the Nestybox public repos on DockerHub.
+
+Feel free to copy them and modify them to your needs, or source them
+from within your Dockerfiles.
+
+# Pulling a Nestybox system container image from DockerHub
+
+For example, to run the system container image that contains Ubuntu Disco + Docker, simply type:
+
+```bash
+$ docker run --runtime=sysbox-runc -it nestybox/ubuntu-disco-docker:latest
+```
+
+# Customizing the system container to your needs
+
+Two approaches: either source the Nestybox image from within your own
+Dockerfile, or copy the Nestybox Dockerfile and modify it.
+
+The former approach makes sense if you wish to leverage the entire image.
+
+The latter approach makes sense if there is some instruction within the
+Nestybox Dockerfile that you wish to change.
+
+## Sourcing the Nestybox Image
+
+Simply add this at the beginning of your Dockerfile
+
+```bash
+FROM nestybox/ubuntu-disco-docker:latest
+```
+
+Then add your instructions to the Dockerfile.
+
+Then build the image and tag it:
+
+```bash
+$ docker build .
+$ docker tag <image-tag> my-custom-syscont:latest
+```
+
+And run it with:
+
+```bash
+$ docker run --runtime=sysbox-runc -it my-custom-syscont:latest
+```
+
+You can then push the image to your own container image repo for later re-use.
+
+## Copy the Dockerfile, modify it, and build a new image
+
+First, copy the Nestybox Dockerfile to some directory, `cd` to that directory, and modify it per your needs.
+
+Then build the image and tag it:
+
+```bash
+$ docker build .
+$ docker tag <image-tag> my-custom-syscont:latest
+```
+
+And run it with:
+
+```bash
+$ docker run --runtime=sysbox-runc -it my-custom-syscont:latest
+```
+
+You can then push the image to your own container image repo for later re-use.

--- a/dockerfiles/debian-stretch-docker/Dockerfile
+++ b/dockerfiles/debian-stretch-docker/Dockerfile
@@ -1,0 +1,25 @@
+#
+# Debian Stretch + Docker
+#
+# Instructions for docker installation taken from:
+# https://docs.docker.com/install/linux/docker-ce/debian/
+#
+
+FROM debian:stretch
+RUN apt-get update
+
+# Docker install
+RUN apt-get install -y \
+       apt-transport-https \
+       ca-certificates \
+       curl \
+       gnupg2 \
+       software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN apt-key fingerprint 0EBFCD88
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+       $(lsb_release -cs) \
+       stable"
+RUN apt-get update
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io

--- a/dockerfiles/ubuntu-disco-docker/Dockerfile
+++ b/dockerfiles/ubuntu-disco-docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# container with ubuntu base image + docker
+# Ubuntu Disco + Docker
 #
 # Instructions for docker installation taken from:
 # https://docs.docker.com/install/linux/docker-ce/ubuntu/
@@ -18,10 +18,9 @@ RUN apt-get install -y \
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN apt-key fingerprint 0EBFCD88
 
-# need edge and test repos as there isn't stable version of docker for ubuntu:disco yet
 RUN add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \
-       stable edge test"
+       stable"
 RUN apt-get update
 RUN apt-get install -y docker-ce docker-ce-cli containerd.io

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,24 +99,21 @@ Moreover, it's fast: the Docker daemon inside the container uses the
 fast overlay2 (or btrfs) storage drivers, rather than alternative
 docker-in-docker solutions that resort to the slower vfs driver.
 
-To run Docker inside a system container (a.k.a Docker-in-Docker),
-the easiest way is to create a system container image that has
-Docker pre-installed in it.
+To run Docker inside a system container (a.k.a Docker-in-Docker), the
+easiest way is to use a system container image that has Docker
+pre-installed in it.
 
-There is a sample Dockerfile [here](../dockerfiles/dind/Dockerfile).
-This Dockerfile simply follows the installation instructions for
-Docker, obtained from the [Docker website](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+You can find a few such images in the Nestybox DockerHub repo:
 
-Download the Dockerfile it and build it:
-
-```bash
-$ docker build -t syscont_with_docker .
+```
+https://hub.docker.com/r/nestybox
 ```
 
-Then launch the system container:
+For example, to run a system container that has Ubuntu Disco + Docker inside, simply
+type:
 
 ```bash
-$ docker run --runtime=sysbox-runc -it --hostname sc syscont_with_docker
+$ docker run --runtime=sysbox-runc -it --hostname sc nestybox/ubuntu-disco-docker:latest
 root@sc:/#
 ```
 
@@ -158,10 +155,15 @@ Status: Downloaded newer image for busybox:latest
 / #
 ```
 
-That's it, the system container is running Docker inside of it, with total
-isolation from the host's Docker daemon.
+As you can see, the system container is running Docker inside of it,
+with total isolation from the host's Docker daemon.
 
-Feel free to copy and modify the Dockerfile shown above to suit your needs.
+The Dockerfiles for the images in the Nestybox repo are
+[here](../dockerfiles/).
+
+Feel free to source the Nestybox sample images from your own Dockerfile,
+or make a copy of a Nestybox Dockerfile and modify it per your needs.
+Instructions for doing so are [here](../dockerfiles/README.md).
 
 ### Inner & Outer Containers
 


### PR DESCRIPTION
The Nestybox DockerHub repo now has public sys container images that make it easy for customers to run a sys container.

This change updates the sysboxd documentation appropriately, and adds the Dockerfiles for the images.

Added contact info to sysboxd README file.